### PR TITLE
Adjust Firebase notification script to new API

### DIFF
--- a/docs/push.php
+++ b/docs/push.php
@@ -1,45 +1,52 @@
 <?php
 
-	header('Content-Type: text/html; charset=utf-8');
+  /* Access like:
+  http://pathto/push.php?channel=123&title=&body=Das Gewicht ist um 10kg (12%) gesunken.
+  Replacement Keys: https://de.mathworks.com/help/thingspeak/thinghttp-app.html#bvtzy2y-5
+  */
 
-	/* Access like:
-	http://pathto/push.php?channel=123&title=&body=Das Gewicht ist um 10kg (12%) gesunken.
-	Replacement Keys: https://de.mathworks.com/help/thingspeak/thinghttp-app.html#bvtzy2y-5
-	*/
+  require __DIR__ . '/vendor/autoload.php';
 
-	// if params are set
-	if (   isset($_REQUEST['channel']) 
-		&& is_numeric($_REQUEST['channel']) 
-		&& (INT)$_REQUEST['channel'] > 0
-		&& isset($_REQUEST['body'])) 
-	{
+  use Google\Auth\ApplicationDefaultCredentials;
+  use GuzzleHttp\Client;
+  use GuzzleHttp\HandlerStack;
 
-		$url = "https://fcm.googleapis.com/fcm/send";
-	    $token = '/topics/'.$_REQUEST['channel'];
-	    $serverKey = 'fcm key';
-	    $title = ($_REQUEST['title']) ? filter_var($_REQUEST['title'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_HIGH) : 'HoneyPi';
-	    $body = filter_var($_REQUEST['body'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_HIGH);
-	    $notification = array('title' => $title , 'body' => $body, 'sound' => 'default', 'badge' => '1');
-	    $arrayToSend = array('to' => $token, 'notification' => $notification,'priority'=>'high');
-	    $json = json_encode($arrayToSend);
-	    $headers = array();
-	    $headers[] = 'Content-Type: application/json';
-	    $headers[] = 'Authorization: key='. $serverKey;
-	    $ch = curl_init();
-	    curl_setopt($ch, CURLOPT_URL, $url);
-	    curl_setopt($ch, CURLOPT_CUSTOMREQUEST,"POST");
-	    curl_setopt($ch, CURLOPT_POSTFIELDS, $json);
-	    curl_setopt($ch, CURLOPT_HTTPHEADER,$headers);
-	    //Send the request
-	    $response = curl_exec($ch);
-	    //Close request
-	    if ($response === FALSE) {
-	    	die('FCM Send Error: ' . curl_error($ch));
-	    }
-		curl_close($ch);
-		echo '<p>Erfolgreich.</p>';
-	} else {
-		echo '<p>Fehler in den Parametern. Bitte überprüfe die Parameter.</p>';
-	}
+  header('Content-Type: text/html; charset=utf-8');
+
+  // if params are set
+  if (   isset($_REQUEST['channel'])
+    && is_numeric($_REQUEST['channel'])
+    && (INT)$_REQUEST['channel'] > 0
+    && isset($_REQUEST['body']))
+  {
+
+    // specify the path to the application credentials
+    putenv('GOOGLE_APPLICATION_CREDENTIALS=/path/to/my/credentials.json');
+
+    $scopes = ['https://www.googleapis.com/auth/firebase.messaging'];
+
+    $middleware = ApplicationDefaultCredentials::getMiddleware($scopes);
+    $stack = HandlerStack::create();
+    $stack->push($middleware);
+
+    $client = new Client([
+      'handler' => $stack,
+      'base_uri' => 'https://fcm.googleapis.com',
+      'auth' => 'google_auth'  // authorize all requests
+    ]);
+
+    $topic = $_REQUEST['channel'];
+    $title = ($_REQUEST['title']) ? filter_var($_REQUEST['title'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_HIGH) : 'HoneyPi';
+    $body = filter_var($_REQUEST['body'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_HIGH);
+    $notification = array('title' => $title , 'body' => $body);
+    $message = array('topic' => $topic, 'notification' => $notification);
+    $requestBody = array('message' => $message);
+
+    $response = $client->post('/v1/projects/honeypi-push-notifications/messages:send', ['json' => $requestBody]);
+
+    echo '<p>Erfolgreich.</p>';
+  } else {
+    echo '<p>Fehler in den Parametern. Bitte überprüfe die Parameter.</p>';
+  }
 
 ?>

--- a/docs/push.php
+++ b/docs/push.php
@@ -5,7 +5,7 @@
   Replacement Keys: https://de.mathworks.com/help/thingspeak/thinghttp-app.html#bvtzy2y-5
   */
 
-  require __DIR__ . '/vendor/autoload.php';
+  require __DIR__ . '/../vendor/autoload.php';
 
   use Google\Auth\ApplicationDefaultCredentials;
   use GuzzleHttp\Client;
@@ -21,7 +21,7 @@
   {
 
     // specify the path to the application credentials
-    putenv('GOOGLE_APPLICATION_CREDENTIALS=/path/to/my/credentials.json');
+    putenv('GOOGLE_APPLICATION_CREDENTIALS=' . __DIR__ . '/../credentials.json');
 
     $scopes = ['https://www.googleapis.com/auth/firebase.messaging'];
 


### PR DESCRIPTION
- Migrated from legacy FCM APIs to HTTP v1: https://firebase.google.com/docs/cloud-messaging/migrate-v1
- Use the Google Auth Library to authenticate with OAuth tokens instead of the server key: https://github.com/googleapis/google-auth-library-php
